### PR TITLE
Accounted for 2's complement output from sensor

### DIFF
--- a/hx711.py
+++ b/hx711.py
@@ -13,13 +13,13 @@ class HX711:
 
         self.GAIN = 0
         self.REFERENCE_UNIT = 1  # The value returned by the hx711 that corresponds to your reference unit AFTER dividing by the SCALE.
-        
+
         self.OFFSET = 1
         self.lastVal = long(0)
 
         self.LSByte = [2, -1, -1]
         self.MSByte = [0, 3, 1]
-        
+
         self.MSBit = [0, 8, 1]
         self.LSBit = [7, -1, -1]
 
@@ -43,7 +43,7 @@ class HX711:
 
         GPIO.output(self.PD_SCK, False)
         self.read()
-    
+
     def createBoolList(self, size=8):
         ret = []
         for i in range(size):
@@ -74,7 +74,10 @@ class HX711:
         #if all(item is True for item in dataBits[0]):
         #    return long(self.lastVal)
 
-        dataBytes[2] ^= 0x80
+        # Test if number is 2's complement negative number
+        if (dataBytes[2] & 0x80):
+            # Number is negative, set MSB to all 1's (255)
+            dataBytes[3] = 0xFF
 
         return dataBytes
 
@@ -97,7 +100,7 @@ class HX711:
                 comma = ""
             np_arr8_string += str(np_arr8[i]) + comma
         np_arr8_string += "]";
-        
+
         return np_arr8_string
 
     def read_np_arr8(self):
@@ -108,7 +111,7 @@ class HX711:
 
     def read_long(self):
         np_arr8 = self.read_np_arr8()
-        np_arr32 = np_arr8.view('uint32')
+        np_arr32 = np_arr8.view('int32')
         self.lastVal = np_arr32
 
         return long(self.lastVal)
@@ -129,7 +132,7 @@ class HX711:
         return value
 
     def tare(self, times=15):
-       
+
         # Backup REFERENCE_UNIT value
         reference_unit = self.REFERENCE_UNIT
         self.set_reference_unit(1)


### PR DESCRIPTION
The sensor outputs 2's complement data according to the [data sheet p.3](https://cdn.sparkfun.com/datasheets/Sensors/ForceFlex/hx711_english.pdf) and it does not look like the library currently follows that.

To account for this, the code checks if the first bit is 1 (meaning a negative number). If so, it changes the most significant byte from 0x00 to 0xFF. It then tells numpy to interpret the array as an int32 rather than a uint32 so that we don't have to do any of the 2's complement math.

This replaces the line where you flip the most significant bit of the number.

*As a note, this is going to significantly change the output of the sensor going forward, so anyone who has hardcoded offset values from prior to this pull request will have to recalculate them using this equation:

`new_offset = old_offset -8388608`
