### PR TITLE
Allow using both channels of a 2-channel HX711 module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+dist/
+*.egg-info/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ versions are updated, also for compatibility.
 I also added a read_median() function that works like the current read_average()
 function, but returns the median of the samples instead of the average.  The
 hope is that this method will help smooth out some spikes in the data that I
-think are CPU load related (I'm using this on a Pi Zero W).  The tare()
-functions have been converted to use this method instead of read_average().
+think are CPU load related (I'm using this on a Pi Zero W).  The tare() and
+get_value() functions have been converted to use this method instead of 
+read_average().
 
 Using a 2-channel HX711 module
 ------------------------------
@@ -29,6 +30,7 @@ TODO:
 -----
   * Incorporate a method for calculating reference value based off of a known
     mass.
+  * Update example.py to handle both channels.
 
 Original README
 ---------------

--- a/README.md
+++ b/README.md
@@ -1,3 +1,38 @@
+hx711.py
+--------
+Forked from https://github.com/tatobari/hx711py to add support for tare/offsets
+for both channels of a 2-channel HX711.
+
+Original tare(), set_offset(), set_reference_unit(), get_value(), get_weight()
+functions call their channel A versions to retain backwards compatibility.  
+Likewise, self.OFFSET and self.REFERENCE_UNIT are updated whenever the channel A
+versions are updated, also for compatibility.
+
+I also added a read_median() function that works like the current read_average()
+function, but returns the median of the samples instead of the average.  The
+hope is that this method will help smooth out some spikes in the data that I
+think are CPU load related (I'm using this on a Pi Zero W).  The tare()
+functions have been converted to use this method instead of read_average().
+
+Using a 2-channel HX711 module
+------------------------------
+Channel A has selectable gain of 128 or 64.  Using set_gain(128) or set_gain(64)
+selects channel A with the specified gain.
+
+Using set_gain(32) selects channel B at the fixed gain of 32.  The tare_B(),
+get_value_B() and get_weight_B() functions do this for you.
+
+This info was obtained from an HX711 datasheet located at
+https://cdn.sparkfun.com/datasheets/Sensors/ForceFlex/hx711_english.pdf
+
+TODO:
+-----
+  * Incorporate a method for calculating reference value based off of a known
+    mass.
+
+Original README
+---------------
+
 Info
 ----
 Quick code credited to Philip Whitfield  "https://github.com/underdoeg/".

--- a/README.md
+++ b/README.md
@@ -34,11 +34,6 @@ get_value_B() and get_weight_B() functions do this for you.
 This info was obtained from an HX711 datasheet located at
 https://cdn.sparkfun.com/datasheets/Sensors/ForceFlex/hx711_english.pdf
 
-TODO:
------
-  * Incorporate a method for calculating reference value based off of a known
-    mass.
-  * Update example.py to handle both channels.
 
 Original README
 ---------------

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ think are CPU load related (I'm using this on a Pi Zero W).  The tare() and
 get_value() functions have been converted to use this method instead of 
 read_average().
 
+Installation
+------------
+1. Clone or download and unpack this repository
+2. In the repository directory, run
+```
+python setup.py install
+```
+
 Using a 2-channel HX711 module
 ------------------------------
 Channel A has selectable gain of 128 or 64.  Using set_gain(128) or set_gain(64)

--- a/example.py
+++ b/example.py
@@ -31,6 +31,10 @@ hx.set_reference_unit(92)
 hx.reset()
 hx.tare()
 
+# to use both channels, you'll need to tare them both
+#hx.tare_A()
+#hx.tare_B()
+
 while True:
     try:
         # These three lines are usefull to debug wether to use MSB or LSB in the reading formats
@@ -43,6 +47,12 @@ while True:
         # Prints the weight. Comment if you're debbuging the MSB and LSB issue.
         val = hx.get_weight(5)
         print val
+
+        # To get weight from both channels (if you have load cells hooked up 
+        # to both channel A and B), do something like this
+        #val_A = hx.get_weight_A(5)
+        #val_B = hx.get_weight_B(5)
+        #print "A: %s  B: %s" % ( val_A, val_B )
 
         hx.power_down()
         hx.power_up()

--- a/hx711.py
+++ b/hx711.py
@@ -2,7 +2,9 @@ import RPi.GPIO as GPIO
 import time
 import numpy  # sudo apt-get python-numpy
 
+
 class HX711:
+
     def __init__(self, dout, pd_sck, gain=128):
         self.PD_SCK = pd_sck
         self.DOUT = dout
@@ -37,8 +39,10 @@ class HX711:
 
         time.sleep(1)
 
+
     def is_ready(self):
         return GPIO.input(self.DOUT) == 0
+
 
     def set_gain(self, gain):
         if gain is 128:
@@ -68,12 +72,14 @@ class HX711:
             ret.append(False)
         return ret
 
+
     def read(self):
         while not self.is_ready():
-            #print("WAITING")
+            # print("WAITING")
             pass
 
-        dataBits = [self.createBoolList(), self.createBoolList(), self.createBoolList()]
+        dataBits = [
+            self.createBoolList(), self.createBoolList(), self.createBoolList()]
         dataBytes = [0x0] * 4
 
         for j in range(self.byte_range_values[0], self.byte_range_values[1], self.byte_range_values[2]):
@@ -83,18 +89,19 @@ class HX711:
                 GPIO.output(self.PD_SCK, False)
             dataBytes[j] = numpy.packbits(numpy.uint8(dataBits[j]))
 
-        #set channel and gain factor for next reading
+        # set channel and gain factor for next reading
         for i in range(self.GAIN):
             GPIO.output(self.PD_SCK, True)
             GPIO.output(self.PD_SCK, False)
 
-        #check for all 1
-        #if all(item is True for item in dataBits[0]):
+        # check for all 1
+        # if all(item is True for item in dataBits[0]):
         #    return long(self.lastVal)
 
         dataBytes[2] ^= 0x80
 
         return dataBytes
+
 
     def get_binary_string(self):
         binary_format = "{0:b}"
@@ -106,23 +113,26 @@ class HX711:
             binary_string += binary_segment + " "
         return binary_string
 
+
     def get_np_arr8_string(self):
         np_arr8 = self.read_np_arr8()
-        np_arr8_string = "[";
+        np_arr8_string = "["
         comma = ", "
         for i in range(4):
             if i is 3:
                 comma = ""
             np_arr8_string += str(np_arr8[i]) + comma
-        np_arr8_string += "]";
+        np_arr8_string += "]"
 
         return np_arr8_string
+
 
     def read_np_arr8(self):
         dataBytes = self.read()
         np_arr8 = numpy.uint8(dataBytes)
 
         return np_arr8
+
 
     def read_long(self):
         np_arr8 = self.read_np_arr8()
@@ -131,12 +141,14 @@ class HX711:
 
         return long(self.lastVal)
 
+
     def read_average(self, times=3):
         values = long(0)
         for i in range(times):
             values += self.read_long()
 
         return values / times
+
 
     # A median-based read method, might help when getting random value spikes
     # for unknown or CPU-related reasons
@@ -147,12 +159,15 @@ class HX711:
 
         return numpy.median(values)
 
+
     # Compatibility function, uses channel A version
     def get_value(self, times=3):
         return self.get_value_A(times)
 
+
     def get_value_A(self, times=3):
         return self.read_median(times) - self.OFFSET_A
+
 
     def get_value_B(self, times=3):
         # for channel B, we need to set_gain(32)
@@ -162,23 +177,28 @@ class HX711:
         self.set_gain(g)
         return value
 
+
     # Compatibility function, uses channel A version
     def get_weight(self, times=3):
         return self.get_weight_A(times)
+
 
     def get_weight_A(self, times=3):
         value = self.get_value_A(times)
         value = value / self.REFERENCE_UNIT_A
         return value
 
+
     def get_weight_B(self, times=3):
         value = self.get_value_B(times)
         value = value / self.REFERENCE_UNIT_B
         return value
 
+
     # Sets tare for channel A for compatibility purposes
     def tare(self, times=15):
         self.tare_A(times)
+
 
     def tare_A(self, times=15):
         # Backup REFERENCE_UNIT value
@@ -189,6 +209,7 @@ class HX711:
         self.set_offset_A(value)
 
         self.set_reference_unit_A(reference_unit)
+
 
     def tare_B(self, times=15):
         # Backup REFERENCE_UNIT value
@@ -205,6 +226,7 @@ class HX711:
         self.set_gain(g)
         self.set_reference_unit_B(reference_unit)
 
+
     def set_reading_format(self, byte_format="LSB", bit_format="MSB"):
         if byte_format == "LSB":
             self.byte_range_values = self.LSByte
@@ -216,39 +238,49 @@ class HX711:
         elif bit_format == "MSB":
             self.bit_range_values = self.MSBit
 
+
     # sets offset for channel A for compatibility reasons
     def set_offset(self, offset):
         self.set_offset_A(offset)
+
 
     def set_offset_A(self, offset):
         self.OFFSET_A = offset
         self.OFFSET = offset
 
+
     def set_offset_B(self, offset):
         self.OFFSET_B = offset
+
 
     # sets reference unit for channel A for compatibility reasons
     def set_reference_unit(self, reference_unit):
         self.set_reference_unit_A(reference_unit)
 
+
     def set_reference_unit_A(self, reference_unit):
         self.REFERENCE_UNIT_A = reference_unit
         self.REFERENCE_UNIT = reference_unit
 
+
     def set_reference_unit_B(self, reference_unit):
         self.REFERENCE_UNIT_B = reference_unit
 
+
     # HX711 datasheet states that setting the PDA_CLOCK pin on high for >60 microseconds would power off the chip.
     # I used 100 microseconds, just in case.
-    # I've found it is good practice to reset the hx711 if it wasn't used for more than a few seconds.
+    # I've found it is good practice to reset the hx711 if it wasn't used for
+    # more than a few seconds.
     def power_down(self):
         GPIO.output(self.PD_SCK, False)
         GPIO.output(self.PD_SCK, True)
         time.sleep(0.0001)
 
+
     def power_up(self):
         GPIO.output(self.PD_SCK, False)
         time.sleep(0.4)
+
 
     def reset(self):
         self.power_down()

--- a/hx711.py
+++ b/hx711.py
@@ -17,11 +17,11 @@ class HX711:
         # unit AFTER dividing by the SCALE.
         self.REFERENCE_UNIT_A = 1
         self.REFERENCE_UNIT_B = 1
-        self.REFERENCE_UNIT = self.REFERENCE_UNIT_A
+        self.REFERENCE_UNIT = 1
 
         self.OFFSET_A = 1
         self.OFFSET_B = 1
-        self.OFFSET = self.OFFSET_A
+        self.OFFSET = 1
         self.lastVal = long(0)
 
         self.LSByte = [2, -1, -1]
@@ -141,14 +141,14 @@ class HX711:
         return self.get_value_A(times)
 
     def get_value_A(self, times=3):
-        return self.read_average(times) - self.OFFSET_A
+        return self.read_median(times) - self.OFFSET_A
 
     def get_value_B(self, times=3):
         # for channel B, we need to set_gain(32)
-        gain = self.GAIN
+        g = self.GAIN
         self.set_gain(32)
-        value = self.read_average(times) - self.OFFSET_B
-        self.set_gain(gain)
+        value = self.read_median(times) - self.OFFSET_B
+        self.GAIN = g
         return value
 
     # Compatibility function, uses channel A version
@@ -185,13 +185,13 @@ class HX711:
         self.set_reference_unit_B(1)
 
         # for channel B, we need to set_gain(32)
-        gain = self.GAIN
+        g = self.GAIN
         self.set_gain(32)
 
         value = self.read_median(times)
         self.set_offset_B(value)
 
-        self.set_gain(gain)
+        self.GAIN = g
         self.set_reference_unit_B(reference_unit)
 
     def set_reading_format(self, byte_format="LSB", bit_format="MSB"):

--- a/hx711.py
+++ b/hx711.py
@@ -17,13 +17,11 @@ class HX711:
 
         # The value returned by the hx711 that corresponds to your reference
         # unit AFTER dividing by the SCALE.
-        self.REFERENCE_UNIT_A = 1
-        self.REFERENCE_UNIT_B = 1
         self.REFERENCE_UNIT = 1
+        self.REFERENCE_UNIT_B = 1
 
-        self.OFFSET_A = 1
-        self.OFFSET_B = 1
         self.OFFSET = 1
+        self.OFFSET_B = 1
         self.lastVal = long(0)
 
         self.LSByte = [2, -1, -1]
@@ -166,7 +164,7 @@ class HX711:
 
 
     def get_value_A(self, times=3):
-        return self.read_median(times) - self.OFFSET_A
+        return self.read_median(times) - self.OFFSET
 
 
     def get_value_B(self, times=3):
@@ -185,7 +183,7 @@ class HX711:
 
     def get_weight_A(self, times=3):
         value = self.get_value_A(times)
-        value = value / self.REFERENCE_UNIT_A
+        value = value / self.REFERENCE_UNIT
         return value
 
 
@@ -202,7 +200,7 @@ class HX711:
 
     def tare_A(self, times=15):
         # Backup REFERENCE_UNIT value
-        reference_unit = self.REFERENCE_UNIT_A
+        reference_unit = self.REFERENCE_UNIT
         self.set_reference_unit_A(1)
 
         value = self.read_median(times)
@@ -245,7 +243,6 @@ class HX711:
 
 
     def set_offset_A(self, offset):
-        self.OFFSET_A = offset
         self.OFFSET = offset
 
 
@@ -259,7 +256,6 @@ class HX711:
 
 
     def set_reference_unit_A(self, reference_unit):
-        self.REFERENCE_UNIT_A = reference_unit
         self.REFERENCE_UNIT = reference_unit
 
 

--- a/hx711.py
+++ b/hx711.py
@@ -50,6 +50,7 @@ class HX711:
 
         GPIO.output(self.PD_SCK, False)
         self.read()
+        time.sleep(0.4)
 
     def createBoolList(self, size=8):
         ret = []
@@ -237,7 +238,7 @@ class HX711:
 
     def power_up(self):
         GPIO.output(self.PD_SCK, False)
-        time.sleep(0.0001)
+        time.sleep(0.4)
 
     def reset(self):
         self.power_down()

--- a/hx711.py
+++ b/hx711.py
@@ -138,7 +138,7 @@ class HX711:
 
     # Compatibility function, uses channel A version
     def get_value(self, times=3):
-        return self.get_value_A(self, times)
+        return self.get_value_A(times)
 
     def get_value_A(self, times=3):
         return self.read_average(times) - self.OFFSET_A
@@ -153,7 +153,7 @@ class HX711:
 
     # Compatibility function, uses channel A version
     def get_weight(self, times=3):
-        return self.get_weight_A(self, times)
+        return self.get_weight_A(times)
 
     def get_weight_A(self, times=3):
         value = self.get_value_A(times)
@@ -167,7 +167,7 @@ class HX711:
 
     # Sets tare for channel A for compatibility purposes
     def tare(self, times=15):
-        self.tare_A(self, times)
+        self.tare_A(times)
 
     def tare_A(self, times=15):
         # Backup REFERENCE_UNIT value
@@ -207,7 +207,7 @@ class HX711:
 
     # sets offset for channel A for compatibility reasons
     def set_offset(self, offset):
-        self.set_offset_A(self, offset)
+        self.set_offset_A(offset)
 
     def set_offset_A(self, offset):
         self.OFFSET_A = offset
@@ -218,7 +218,7 @@ class HX711:
 
     # sets reference unit for channel A for compatibility reasons
     def set_reference_unit(self, reference_unit):
-        self.set_reference_unit_A(self, reference_unit)
+        self.set_reference_unit_A(reference_unit)
 
     def set_reference_unit_A(self, reference_unit):
         self.REFERENCE_UNIT_A = reference_unit

--- a/hx711.py
+++ b/hx711.py
@@ -52,6 +52,16 @@ class HX711:
         self.read()
         time.sleep(0.4)
 
+
+    def get_gain(self):
+        if self.GAIN == 1:
+            return 128
+        elif self.GAIN == 3:
+            return 64
+        elif self.GAIN == 2:
+            return 32
+
+
     def createBoolList(self, size=8):
         ret = []
         for i in range(size):
@@ -146,10 +156,10 @@ class HX711:
 
     def get_value_B(self, times=3):
         # for channel B, we need to set_gain(32)
-        g = self.GAIN
+        g = self.get_gain()
         self.set_gain(32)
         value = self.read_median(times) - self.OFFSET_B
-        self.GAIN = g
+        self.set_gain(g)
         return value
 
     # Compatibility function, uses channel A version
@@ -186,13 +196,13 @@ class HX711:
         self.set_reference_unit_B(1)
 
         # for channel B, we need to set_gain(32)
-        g = self.GAIN
+        g = self.get_gain()
         self.set_gain(32)
 
         value = self.read_median(times)
         self.set_offset_B(value)
 
-        self.GAIN = g
+        self.set_gain(g)
         self.set_reference_unit_B(reference_unit)
 
     def set_reading_format(self, byte_format="LSB", bit_format="MSB"):

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+
+setup(
+    name='hx711',
+    version='0.1',
+    description='HX711 Python Library for Raspberry Pi',
+    py_modules=['hx711'],
+    install_requires=['Rpi.GPIO', 'numpy'],
+)
+


### PR DESCRIPTION
I modified hx711.py to make it easier to get data from both channels of an HX711 module.  

While I could read channel 2 with the existing code by using set_gain(32), the offset and reference values were different because they had been set up for channel 1.  I added separate offset and reference variables for channel A and B, and kept the old variables to make the code as backwards compatible as possible.

For each of the tare(), set_offset(), set_reference_unit(), get_value(), and get_weight() functions I added separate versions for channel A and B.  The original functions call the channel A versions directly to maintain compatibility.

I also added a read_median() function that uses median instead of average when reading data.  I was getting a lot of nasty spikes that I couldn't track down, and using the median of the data instead of the average seemed to help.  I changed the tare() and get_value() functions to use read_median(), but I left the read_average() function in case someone is using it directly.

Finally, I did some general cleanup - added a basic setup.py to allow installing this as a proper module, added to the README.md, and added a .gitignore file to ignore leftovers from module building.