### PR TITLE
Tab/space inconsistency

### DIFF
--- a/hx711.py
+++ b/hx711.py
@@ -98,11 +98,11 @@ class HX711:
         if self.byte_format == 'LSB':
             self.MSBindex24Bit = 1
             self.MSBindex32Bit = 0
-        
+
         if dataBytes[self.MSBindex24Bit] & 0x80:
             self.isNegative = True
 
-	dataBytes[self.MSBindex32Bit] = numpy.packbits(dataBits[self.MSBindex32Bit].astype(int))[0]
+        dataBytes[self.MSBindex32Bit] = numpy.packbits(dataBits[self.MSBindex32Bit].astype(int))[0]
 
         return dataBytes
 


### PR DESCRIPTION
Hi,
Found an error due to an inconsistent use of tabs and spaces on line 105. The error popped up after I cloned the latest repository. Quickly swapped it with spaces as seemed the norm throughout the file :)