### PR TITLE
Python3 support

### DIFF
--- a/emulated_hx711.py
+++ b/emulated_hx711.py
@@ -132,7 +132,7 @@ class HX711:
 
 
         if self.DEBUG_PRINTING:
-            print dataBytes,
+            print(dataBytes,)
         
         # Join the raw bytes into a single 24bit 2s complement value.
         twosComplementValue = ((dataBytes[0] << 16) |
@@ -140,7 +140,7 @@ class HX711:
                                dataBytes[2])
 
         if self.DEBUG_PRINTING:
-            print "Twos: 0x%06x" % twosComplementValue
+            print("Twos: 0x%06x" % twosComplementValue)
         
         # Convert from 24bit twos-complement to a signed value.
         signedIntValue = self.convertFromTwosComplement24bit(twosComplementValue)
@@ -149,13 +149,13 @@ class HX711:
         self.lastVal = signedIntValue
 
         # Return the sample value we've read from the HX711.
-        return long(signedIntValue)
+        return int(signedIntValue)
 
     
     def read_average(self, times=3):
         # Make sure we've been asked to take a rational amount of samples.
         if times <= 0:
-            print "HX711().read_average(): times must >= 1!!  Assuming value of 1."
+            print("HX711().read_average(): times must >= 1!!  Assuming value of 1.")
             times = 1
 
         # If we're only average across one value, just read it and return it.
@@ -165,7 +165,7 @@ class HX711:
         # If we're averaging across a low amount of values, just take an
         # arithmetic mean.
         if times < 5:
-            values = long(0)
+            values = int(0)
             for i in range(times):
                 values += self.read_long()
 
@@ -212,7 +212,7 @@ class HX711:
         value = self.read_average(times)
 
         if self.DEBUG_PRINTING:
-            print "Tare value:", value
+            print("Tare value:", value)
         
         self.set_offset(value)
 
@@ -229,14 +229,14 @@ class HX711:
         elif byte_format == "MSB":
             self.byte_format = byte_format
         else:
-            print "Unrecognised byte_format: \"%s\"" % byte_format
+            print("Unrecognised byte_format: \"%s\"" % byte_format)
 
         if bit_format == "LSB":
             self.bit_format = bit_format
         elif bit_format == "MSB":
             self.bit_format = bit_format
         else:
-            print "Unrecognised bit_format: \"%s\"" % bit_format
+            print("Unrecognised bit_format: \"%s\"" % bit_format)
 
             
 
@@ -251,7 +251,7 @@ class HX711:
     def set_reference_unit(self, reference_unit):
         # Make sure we aren't asked to use an invalid reference unit.
         if reference_unit == 0:
-            print "HX711().set_reference_unit(): Can't use 0 as a reference unit!!"
+            print("HX711().set_reference_unit(): Can't use 0 as a reference unit!!")
             return
 
         self.REFERENCE_UNIT = reference_unit
@@ -318,7 +318,7 @@ class HX711:
 
        if random.randrange(0, BIG_ERROR_SAMPLE_FREQUENCY) == 0:
           sample = random.sample(BIG_ERROR_SAMPLES, 1)[0]
-          print "Sample %d: Injecting %f as a random bad sample." % (self.sampleCount, sample)
+          print("Sample %d: Injecting %f as a random bad sample." % (self.sampleCount, sample))
 
        sample *= 1000
 

--- a/example.py
+++ b/example.py
@@ -5,6 +5,8 @@ import sys
 
 EMULATE_HX711=False
 
+referenceUnit = 1
+
 if not EMULATE_HX711:
     import RPi.GPIO as GPIO
     from hx711 import HX711
@@ -37,7 +39,7 @@ hx.set_reading_format("MSB", "MSB")
 # and I got numbers around 184000 when I added 2kg. So, according to the rule of thirds:
 # If 2000 grams is 184000 then 1000 grams is 184000 / 2000 = 92.
 #hx.set_reference_unit(113)
-hx.set_reference_unit(1)
+hx.set_reference_unit(referenceUnit)
 
 hx.reset()
 

--- a/example.py
+++ b/example.py
@@ -63,7 +63,7 @@ while True:
         
         # Prints the weight. Comment if you're debbuging the MSB and LSB issue.
         val = hx.get_weight(5)
-        print val
+        print(val)
 
         # To get weight from both channels (if you have load cells hooked up 
         # to both channel A and B), do something like this

--- a/example.py
+++ b/example.py
@@ -12,12 +12,12 @@ else:
     from emulated_hx711 import HX711
 
 def cleanAndExit():
-    print "Cleaning..."
+    print("Cleaning...")
 
     if not EMULATE_HX711:
         GPIO.cleanup()
         
-    print "Bye!"
+    print("Bye!")
     sys.exit()
 
 hx = HX711(5, 6)
@@ -43,7 +43,7 @@ hx.reset()
 
 hx.tare()
 
-print "Tare done! Add weight now..."
+print("Tare done! Add weight now...")
 
 # to use both channels, you'll need to tare them both
 #hx.tare_A()

--- a/hx711.py
+++ b/hx711.py
@@ -216,7 +216,7 @@ class HX711:
 
        # If times is odd we can just take the centre value.
        if (times & 0x1) == 0x1:
-          return valueList[len(valueList) / 2] 
+          return valueList[len(valueList) // 2]
        else:
           # If times is even we have to take the arithmetic mean of
           # the two middle values.

--- a/hx711.py
+++ b/hx711.py
@@ -230,14 +230,14 @@ class HX711:
 
 
     def get_value_A(self, times=3):
-        return self.read_median(times) - self.OFFSET
+        return self.read_median(times) - self.get_offset_A()
 
 
     def get_value_B(self, times=3):
         # for channel B, we need to set_gain(32)
         g = self.get_gain()
         self.set_gain(32)
-        value = self.read_median(times) - self.OFFSET_B
+        value = self.read_median(times) - self.get_offset_B()
         self.set_gain(g)
         return value
 

--- a/hx711.py
+++ b/hx711.py
@@ -30,7 +30,7 @@ class HX711:
 
         self.OFFSET = 1
         self.OFFSET_B = 1
-        self.lastVal = long(0)
+        self.lastVal = int(0)
 
         self.DEBUG_PRINTING = False
 
@@ -144,7 +144,7 @@ class HX711:
 
 
         if self.DEBUG_PRINTING:
-            print dataBytes,
+            print(dataBytes,)
         
         # Join the raw bytes into a single 24bit 2s complement value.
         twosComplementValue = ((dataBytes[0] << 16) |
@@ -152,7 +152,7 @@ class HX711:
                                dataBytes[2])
 
         if self.DEBUG_PRINTING:
-            print "Twos: 0x%06x" % twosComplementValue
+            print("Twos: 0x%06x" % twosComplementValue)
         
         # Convert from 24bit twos-complement to a signed value.
         signedIntValue = self.convertFromTwosComplement24bit(twosComplementValue)
@@ -161,7 +161,7 @@ class HX711:
         self.lastVal = signedIntValue
 
         # Return the sample value we've read from the HX711.
-        return long(signedIntValue)
+        return int(signedIntValue)
 
     
     def read_average(self, times=3):
@@ -270,7 +270,7 @@ class HX711:
         value = self.read_average(times)
 
         if self.DEBUG_PRINTING:
-            print "Tare A value:", value
+            print("Tare A value:", value)
         
         self.set_offset_A(value)
 
@@ -292,7 +292,7 @@ class HX711:
         value = self.read_average(times)
 
         if self.DEBUG_PRINTING:
-            print "Tare B value:", value
+            print("Tare B value:", value)
         
         self.set_offset_B(value)
 


### PR DESCRIPTION
Hi,

I really like your Code! Thanks a lot for your work!
Anyway, I started a small project and tried to use your code with Python3 which didn't work due to some datatype and syntax changes from Python2 to Python3.
The function long() works only with type str in the brackets in Python3. Plus, all integers now have unlimited precision which made me use int() instead of long().
print requires brackets in Python3 also. Which means: print str had to be changed to print(str).

If you have any more ideas how to improve the Code for Python 3 I'd really appreciate it!

Thanks a lot again for your work.

Cheers!