### PR TITLE
add missing return

### DIFF
--- a/hx711.py
+++ b/hx711.py
@@ -259,7 +259,7 @@ class HX711:
     
     # Sets tare for channel A for compatibility purposes
     def tare(self, times=15):
-        self.tare_A(times)
+        return self.tare_A(times)
     
     
     def tare_A(self, times=15):


### PR DESCRIPTION
I think that this "return" was forgotten, if we follow the similar functions you added for compatibility.