### PR TITLE
Indentation fixes, and minor spelling fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HX711 for Raspbery Py
+# HX711 for Raspberry Pi
 ----
 Quick code credited to [underdoeg](https://github.com/underdoeg/)'s [Gist HX711.py](https://gist.github.com/underdoeg/98a38b54f889fce2b237).
 I've only made a few modifications on the way the captured bits are processed and to support Two's Complement, which it didn't.
@@ -29,4 +29,3 @@ get_value_B() and get_weight_B() functions do this for you.
 
 This info was obtained from an HX711 datasheet located at
 https://cdn.sparkfun.com/datasheets/Sensors/ForceFlex/hx711_english.pdf
-

--- a/hx711.py
+++ b/hx711.py
@@ -5,7 +5,6 @@ import time
 import threading
 
 
-
 class HX711:
 
     def __init__(self, dout, pd_sck, gain=128):
@@ -16,7 +15,7 @@ class HX711:
         # Mutex for reading from the HX711, in case multiple threads in client
         # software try to access get values from the class at the same time.
         self.readLock = threading.Lock()
-        
+
         GPIO.setmode(GPIO.BCM)
         GPIO.setup(self.PD_SCK, GPIO.OUT)
         GPIO.setup(self.DOUT, GPIO.IN)
@@ -42,21 +41,21 @@ class HX711:
         # Think about whether this is necessary.
         time.sleep(1)
 
-        
+
     def convertFromTwosComplement24bit(self, inputValue):
         return -(inputValue & 0x800000) + (inputValue & 0x7fffff)
 
-    
+
     def is_ready(self):
         return GPIO.input(self.DOUT) == 0
 
-    
+
     def set_gain(self, gain):
-        if gain is 128:
+        if gain == 128:
             self.GAIN = 1
-        elif gain is 64:
+        elif gain == 64:
             self.GAIN = 3
-        elif gain is 32:
+        elif gain == 32:
             self.GAIN = 2
 
         GPIO.output(self.PD_SCK, False)
@@ -64,7 +63,7 @@ class HX711:
         # Read out a set of raw bytes and throw it away.
         self.readRawBytes()
 
-        
+
     def get_gain(self):
         if self.GAIN == 1:
             return 128
@@ -75,36 +74,36 @@ class HX711:
 
         # Shouldn't get here.
         return 0
-        
+
 
     def readNextBit(self):
-       # Clock HX711 Digital Serial Clock (PD_SCK).  DOUT will be
-       # ready 1us after PD_SCK rising edge, so we sample after
-       # lowering PD_SCL, when we know DOUT will be stable.
-       GPIO.output(self.PD_SCK, True)
-       GPIO.output(self.PD_SCK, False)
-       value = GPIO.input(self.DOUT)
+        # Clock HX711 Digital Serial Clock (PD_SCK).  DOUT will be
+        # ready 1us after PD_SCK rising edge, so we sample after
+        # lowering PD_SCL, when we know DOUT will be stable.
+        GPIO.output(self.PD_SCK, True)
+        GPIO.output(self.PD_SCK, False)
+        value = GPIO.input(self.DOUT)
 
-       # Convert Boolean to int and return it.
-       return int(value)
+        # Convert Boolean to int and return it.
+        return int(value)
 
 
     def readNextByte(self):
-       byteValue = 0
+        byteValue = 0
 
-       # Read bits and build the byte from top, or bottom, depending
-       # on whether we are in MSB or LSB bit mode.
-       for x in range(8):
-          if self.bit_format == 'MSB':
-             byteValue <<= 1
-             byteValue |= self.readNextBit()
-          else:
-             byteValue >>= 1              
-             byteValue |= self.readNextBit() * 0x80
+        # Read bits and build the byte from top, or bottom, depending
+        # on whether we are in MSB or LSB bit mode.
+        for x in range(8):
+            if self.bit_format == 'MSB':
+                byteValue <<= 1
+                byteValue |= self.readNextBit()
+            else:
+                byteValue >>= 1
+                byteValue |= self.readNextBit() * 0x80
 
-       # Return the packed byte.
-       return byteValue 
-        
+        # Return the packed byte.
+        return byteValue
+
 
     def readRawBytes(self):
         # Wait for and get the Read Lock, incase another thread is already
@@ -113,7 +112,7 @@ class HX711:
 
         # Wait until HX711 is ready for us to read a sample.
         while not self.is_ready():
-           pass
+            pass
 
         # Read three bytes of data from the HX711.
         firstByte  = self.readNextByte()
@@ -123,19 +122,19 @@ class HX711:
         # HX711 Channel and gain factor are set by number of bits read
         # after 24 data bits.
         for i in range(self.GAIN):
-           # Clock a bit out of the HX711 and throw it away.
-           self.readNextBit()
+            # Clock a bit out of the HX711 and throw it away.
+            self.readNextBit()
 
         # Release the Read Lock, now that we've finished driving the HX711
         # serial interface.
-        self.readLock.release()           
+        self.readLock.release()
 
         # Depending on how we're configured, return an orderd list of raw byte
         # values.
         if self.byte_format == 'LSB':
-           return [thirdByte, secondByte, firstByte]
+            return [thirdByte, secondByte, firstByte]
         else:
-           return [firstByte, secondByte, thirdByte]
+            return [firstByte, secondByte, thirdByte]
 
 
     def read_long(self):
@@ -144,8 +143,8 @@ class HX711:
 
 
         if self.DEBUG_PRINTING:
-            print(dataBytes,)
-        
+            print(dataBytes)
+
         # Join the raw bytes into a single 24bit 2s complement value.
         twosComplementValue = ((dataBytes[0] << 16) |
                                (dataBytes[1] << 8)  |
@@ -153,7 +152,7 @@ class HX711:
 
         if self.DEBUG_PRINTING:
             print("Twos: 0x%06x" % twosComplementValue)
-        
+
         # Convert from 24bit twos-complement to a signed value.
         signedIntValue = self.convertFromTwosComplement24bit(twosComplementValue)
 
@@ -163,7 +162,7 @@ class HX711:
         # Return the sample value we've read from the HX711.
         return int(signedIntValue)
 
-    
+
     def read_average(self, times=3):
         # Make sure we've been asked to take a rational amount of samples.
         if times <= 0:
@@ -200,28 +199,28 @@ class HX711:
     # A median-based read method, might help when getting random value spikes
     # for unknown or CPU-related reasons
     def read_median(self, times=3):
-       if times <= 0:
-          raise ValueError("HX711::read_median(): times must be greater than zero!")
-      
-       # If times == 1, just return a single reading.
-       if times == 1:
-          return self.read_long()
+        if times <= 0:
+            raise ValueError("HX711::read_median(): times must be greater than zero!")
 
-       valueList = []
+        # If times == 1, just return a single reading.
+        if times == 1:
+            return self.read_long()
 
-       for x in range(times):
-          valueList += [self.read_long()]
+        valueList = []
 
-       valueList.sort()
+        for x in range(times):
+            valueList += [self.read_long()]
 
-       # If times is odd we can just take the centre value.
-       if (times & 0x1) == 0x1:
-          return valueList[len(valueList) // 2]
-       else:
-          # If times is even we have to take the arithmetic mean of
-          # the two middle values.
-          midpoint = len(valueList) / 2
-          return sum(valueList[midpoint:midpoint+2]) / 2.0
+        valueList.sort()
+
+        # If times is odd we can just take the centre value.
+        if (times & 0x1) == 0x1:
+            return valueList[len(valueList) // 2]
+        else:
+            # If times is even we have to take the arithmetic mean of
+            # the two middle values.
+            midpoint = len(valueList) / 2
+            return sum(valueList[midpoint:midpoint + 2]) / 2.0
 
 
     # Compatibility function, uses channel A version
@@ -256,22 +255,22 @@ class HX711:
         value = value / self.REFERENCE_UNIT_B
         return value
 
-    
+
     # Sets tare for channel A for compatibility purposes
     def tare(self, times=15):
         return self.tare_A(times)
-    
-    
+
+
     def tare_A(self, times=15):
         # Backup REFERENCE_UNIT value
         backupReferenceUnit = self.get_reference_unit_A()
         self.set_reference_unit_A(1)
-        
+
         value = self.read_average(times)
 
         if self.DEBUG_PRINTING:
             print("Tare A value:", value)
-        
+
         self.set_offset_A(value)
 
         # Restore the reference unit, now that we've got our offset.
@@ -293,17 +292,17 @@ class HX711:
 
         if self.DEBUG_PRINTING:
             print("Tare B value:", value)
-        
+
         self.set_offset_B(value)
 
         # Restore gain/channel/reference unit settings.
         self.set_gain(backupGain)
         self.set_reference_unit_B(backupReferenceUnit)
-       
+
         return value
 
 
-    
+
     def set_reading_format(self, byte_format="LSB", bit_format="MSB"):
         if byte_format == "LSB":
             self.byte_format = byte_format
@@ -319,7 +318,7 @@ class HX711:
         else:
             raise ValueError("Unrecognised bitformat: \"%s\"" % bit_format)
 
-            
+
 
 
     # sets offset for channel A for compatibility reasons
@@ -342,11 +341,11 @@ class HX711:
         return self.OFFSET_B
 
 
-    
+
     def set_reference_unit(self, reference_unit):
         self.set_reference_unit_A(reference_unit)
 
-        
+
     def set_reference_unit_A(self, reference_unit):
         # Make sure we aren't asked to use an invalid reference unit.
         if reference_unit == 0:
@@ -355,7 +354,7 @@ class HX711:
 
         self.REFERENCE_UNIT = reference_unit
 
-        
+
     def set_reference_unit_B(self, reference_unit):
         # Make sure we aren't asked to use an invalid reference unit.
         if reference_unit == 0:
@@ -366,17 +365,17 @@ class HX711:
 
 
     def get_reference_unit(self):
-        return get_reference_unit_A()
+        return self.get_reference_unit_A()
 
-        
+
     def get_reference_unit_A(self):
         return self.REFERENCE_UNIT
 
-        
+
     def get_reference_unit_B(self):
         return self.REFERENCE_UNIT_B
-        
-        
+
+
     def power_down(self):
         # Wait for and get the Read Lock, incase another thread is already
         # driving the HX711 serial interface.
@@ -392,7 +391,7 @@ class HX711:
 
         # Release the Read Lock, now that we've finished driving the HX711
         # serial interface.
-        self.readLock.release()           
+        self.readLock.release()
 
 
     def power_up(self):


### PR DESCRIPTION
There was a lot of code indented 7 spaces instead of 8, etc. Fixed all of it.

Also fixed typo "Raspbery Py" -> "Raspberry Pi"