### PR TITLE
Removed delay on construction and added delay in infinite loop

### DIFF
--- a/hx711v0_5_1.py
+++ b/hx711v0_5_1.py
@@ -32,14 +32,6 @@ class HX711:
         # GAIN must be between 1 and 3. None is an invalid value.
         self.GAIN = None
         self.setGain(gain)
-
-
-        # Think about whether this is necessary.
-        time.sleep(1)
-
-        
-        # Think about whether this is necessary.
-        time.sleep(1)
         
         self.readyCallbackEnabled = False
         self.paramCallback = None
@@ -196,7 +188,7 @@ class HX711:
 
         # Wait until HX711 is ready for us to read a sample.
         while self.isReady() is not True:
-           pass
+            time.sleep(0.1)
 
         # Read three bytes of data from the HX711.
         firstByte  = self.readNextByte()


### PR DESCRIPTION
Removed the delays in the constructor and added a small delay in the infinite loop while we wait for the the HX711 module to become ready. I found that without this delay the code would get stuck there forever when I construct and autsetOffset() two load cells in a row.